### PR TITLE
Dual debian build python2+3

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos Python toolkit.
 Release 0.2.1 (pending)
 ==========================
 
+- Dual python2 + python3 build for debian packaging
 - Additional build helpers for python development config
 - Added missing debian install files
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,10 @@ Build-Depends:
     cmake (>= 2.8.9),
     libpoco-dev (>= 1.6),
     libpothos-dev,
-    libpython-dev, python
+    python,
+    python-dev,
+    python3,
+    python3-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/pothosware/pothos-python/wiki
 Vcs-Git: https://github.com/pothosware/pothos-python.git
@@ -16,6 +19,7 @@ Vcs-Browser: https://github.com/pothosware/pothos-python
 Package: pothos-modules0.4-3-python
 Section: libs
 Architecture: any
+Conflicts: pothos-modules0.4-3-python3
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Python language bindings - plugins
@@ -26,6 +30,7 @@ Section: python
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-numpy, pothos-modules0.4-3-python
+Recommends: pothos-python-dev
 Description: Python language bindings - python module
  The Pothos data-flow software suite.
 
@@ -35,4 +40,22 @@ Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, pothos-modules0.4-3-python
 Description: Python language bindings - development files
+ The Pothos data-flow software suite.
+
+Package: pothos-modules0.4-3-python3
+Section: libs
+Architecture: any
+Conflicts: pothos-modules0.4-3-python
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Python3 language bindings - plugins
+ The Pothos data-flow software suite.
+
+Package: python3-pothos
+Section: python
+Architecture: any
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3-numpy, pothos-modules0.4-3-python3
+Recommends: pothos-python-dev
+Description: Python3 language bindings - python module
  The Pothos data-flow software suite.

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Vcs-Browser: https://github.com/pothosware/pothos-python
 Package: pothos-modules0.4-3-python
 Section: libs
 Architecture: any
+Replaces: pothos-modules0.4-3-python3
 Conflicts: pothos-modules0.4-3-python3
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -38,13 +39,14 @@ Package: pothos-python-dev
 Section: libs
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, pothos-modules0.4-3-python
+Depends: ${misc:Depends}
 Description: Python language bindings - development files
  The Pothos data-flow software suite.
 
 Package: pothos-modules0.4-3-python3
 Section: libs
 Architecture: any
+Replaces: pothos-modules0.4-3-python
 Conflicts: pothos-modules0.4-3-python
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}

--- a/debian/pothos-modules0.4-3-python3.install.in
+++ b/debian/pothos-modules0.4-3-python3.install.in
@@ -1,0 +1,1 @@
+python3/usr/lib/*/Pothos/modules* usr/lib/@DEB_HOST_MULTIARCH@/Pothos

--- a/debian/python-pothos.install
+++ b/debian/python-pothos.install
@@ -1,1 +1,1 @@
-usr/lib/python*
+usr/lib/python2*

--- a/debian/python3-pothos.install
+++ b/debian/python3-pothos.install
@@ -1,0 +1,1 @@
+python3/usr/lib/python3* usr/lib

--- a/debian/rules
+++ b/debian/rules
@@ -10,14 +10,40 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+# create generated install files with the multi-arch directory
+# this is needed due to --destdir and use of wildcard matching
+GENERATED_INSTALL_FILES := \
+	debian/pothos-modules0.4-3-python3.install
+
+debian/%.install: debian/%.install.in
+	sed 's/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/g' $< > $@
 
 %:
-	dh $@ --buildsystem=cmake --parallel
+	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- \
+	mkdir -p build-python2 && cd build-python2 && cmake ../ \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DPython_ADDITIONAL_VERSIONS=2 \
 		-DLIB_SUFFIX="/$(DEB_HOST_MULTIARCH)" \
 		-DCMAKE_SKIP_RPATH=TRUE
+	mkdir -p build-python3 && cd build-python3 && cmake ../ \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DPython_ADDITIONAL_VERSIONS=3 \
+		-DLIB_SUFFIX="/$(DEB_HOST_MULTIARCH)" \
+		-DCMAKE_SKIP_RPATH=TRUE
+
+override_dh_auto_build:
+	dh_auto_build --builddirectory build-python2
+	dh_auto_build --builddirectory build-python3
+
+override_dh_auto_install: $(GENERATED_INSTALL_FILES)
+	dh_auto_install --builddirectory build-python2
+	dh_auto_install --builddirectory build-python3 --destdir python3
+
+override_dh_auto_clean:
+	dh_auto_clean --builddirectory build-python2
+	dh_auto_clean --builddirectory build-python3
 
 override_dh_installchangelogs:
 	dh_installchangelogs Changelog.txt

--- a/debian/rules
+++ b/debian/rules
@@ -19,15 +19,15 @@ debian/%.install: debian/%.install.in
 	sed 's/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/g' $< > $@
 
 %:
-	dh $@ --parallel
+	dh $@ --buildsystem=cmake --parallel
 
 override_dh_auto_configure:
-	mkdir -p build-python2 && cd build-python2 && cmake ../ \
+	dh_auto_configure --builddirectory build-python2 -- \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DPython_ADDITIONAL_VERSIONS=2 \
 		-DLIB_SUFFIX="/$(DEB_HOST_MULTIARCH)" \
 		-DCMAKE_SKIP_RPATH=TRUE
-	mkdir -p build-python3 && cd build-python3 && cmake ../ \
+	dh_auto_configure --builddirectory build-python3 -- \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DPython_ADDITIONAL_VERSIONS=3 \
 		-DLIB_SUFFIX="/$(DEB_HOST_MULTIARCH)" \
@@ -44,6 +44,9 @@ override_dh_auto_install: $(GENERATED_INSTALL_FILES)
 override_dh_auto_clean:
 	dh_auto_clean --builddirectory build-python2
 	dh_auto_clean --builddirectory build-python3
+
+override_dh_auto_test:
+	echo "No tests"
 
 override_dh_installchangelogs:
 	dh_installchangelogs Changelog.txt


### PR DESCRIPTION
Modifications to debian control and rules to build twice for both python versions to create python and python3 packages.

* Related: https://github.com/pothosware/pothos-python/issues/8